### PR TITLE
Item Durability added to the HUD

### DIFF
--- a/src/client/java/at/korny/ItemDurability.java
+++ b/src/client/java/at/korny/ItemDurability.java
@@ -1,0 +1,19 @@
+package at.korny;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+public class ItemDurability {
+    public static int getItemDurability(PlayerEntity player) {
+        ItemStack heldItem = player.getMainHandStack(); // Holt das Item in der Haupthand
+
+        if (!heldItem.isEmpty() && heldItem.isDamageable()) { // Prüft, ob das Item Haltbarkeit hat
+            return heldItem.getMaxDamage() - heldItem.getDamage();
+        }
+        return -1; // Falls das Item keine Haltbarkeit hat
+
+        //public static int = heldItem.getMaxDamage() - heldItem.getDamage();
+    }
+
+}

--- a/src/client/java/at/korny/JosefclientClient.java
+++ b/src/client/java/at/korny/JosefclientClient.java
@@ -10,6 +10,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 
 public class JosefclientClient implements ClientModInitializer {
 	private boolean rotating = false;
@@ -93,6 +95,7 @@ public class JosefclientClient implements ClientModInitializer {
 		String biome = BiomeHelper.getPlayerBiome();
 		String direction = PlayerDirectionHelper.getCardinalDirection();
 
+		PlayerEntity player = client.player;
 		if (client.player != null) {
 			context.drawText(client.textRenderer, "[X] " + String.valueOf(x), 10, 25, 0xFFFFFF, true);
 			context.drawText(client.textRenderer, "[Y] " + String.valueOf(y), 10, 35, 0xFFFFFF, true);
@@ -100,7 +103,8 @@ public class JosefclientClient implements ClientModInitializer {
 			context.drawText(client.textRenderer, "[Biome] " + String.valueOf(biome), 10, 55, 0xFFFFFF, true);
 			context.drawText(client.textRenderer, "[Direction] " + direction, 10, 65, 0xFFFFFF, true);
 			context.drawText(client.textRenderer, "[Version]" + Version.version(), 10 , 75, 0xFFFFFF, true);
-			context.drawText(client.textRenderer, "[JosefClient]", 120, 10, 0xFFFFFF, true);
+			context.drawText(client.textRenderer, "[JosefClient]", 300, 10, 0xFFFFFF, true);
+			context.drawText(client.textRenderer, "[Current Item Durability]" + ItemDurability.getItemDurability(player), 10, 100, 0xFFFFFF, true);
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces a new feature to display the durability of the currently held item in the game. The changes include the creation of a new class to handle item durability and modifications to the existing client class to integrate this new feature.

### New Feature: Item Durability Display

* [`src/client/java/at/korny/ItemDurability.java`](diffhunk://#diff-03a70640308e7c13b3fc6dda01b3044d32e0ffdfdd6819d8a6c8d467016ed25dR1-R19): Added a new class `ItemDurability` to calculate the durability of the item currently held by the player. This class includes a method `getItemDurability` that returns the remaining durability of the item.

### Integration with Existing Client

* [`src/client/java/at/korny/JosefclientClient.java`](diffhunk://#diff-ce8c13ba3d691ab9afe74c4d149f7e83f27e8652d6e43335ed070f857f7a3e47R13-R14): Imported necessary classes `PlayerEntity` and `ItemStack` to support the new durability feature.
* [`src/client/java/at/korny/JosefclientClient.java`](diffhunk://#diff-ce8c13ba3d691ab9afe74c4d149f7e83f27e8652d6e43335ed070f857f7a3e47R98-R107): Updated the `coordsRenderer` method to include the player entity and display the current item durability on the screen. The durability is fetched using the `ItemDurability.getItemDurability` method. Additionally, the position of the "JosefClient" text was adjusted on the screen.